### PR TITLE
Update to make it build/run with new functions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 group 'com.bunq.tinker'
-version '0.0.1'
+version '0.0.2'
 
 apply plugin: 'java'
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 sourceCompatibility = 1.8
 
 repositories {
@@ -11,10 +11,10 @@ repositories {
 }
 
 dependencies {
-    testCompile group: 'junit', name: 'junit', version: '4.12'
+    testImplementation group: 'junit', name: 'junit', version: '4.12'
     // https://mvnrepository.com/artifact/commons-cli/commons-cli
-    compile group: 'commons-cli', name: 'commons-cli', version: '1.2'
-    compile 'com.github.bunq:sdk_java:1.13.1'
+    implementation group: 'commons-cli', name: 'commons-cli', version: '1.2'
+    implementation 'com.github.bunq:sdk_java:1.13.1'
 }
 
 compileJava {
@@ -24,7 +24,7 @@ compileJava {
 jar {
     manifest {
         attributes ('Main-Class': 'com.bunq.tinker.utils.TinkerRunner',
-                "Class-Path": configurations.compile.collect { it.absolutePath }.join(' ')
+                "Class-Path": configurations.runtimeClasspath.files.collect { it.absolutePath }.join(' ')
         )
     }
 }


### PR DESCRIPTION
Scarcely tested on Darwin (MacOS Ventura).

Problem: with the current version provided by bunq, 'gradle build' will fail with multiple hard failures due to using deprecated/removed features. (As of version 8.0). Also maven has been renamed and relocated.

This quick fix makes "gradle build" complete successfully and creates the .jar files so that you can actually use Tinker again. :) (However only for PRODUCTION; because for tinkering/sandbox: just like the other SDK's (Python & PHP), it will fail to run claiming the endpoint is outdated. Sandbox will actually load fine after these changes, but it will error out with the "Your application version does not support this endpoint, please update your app" failure. )

Tested my changes in PRODUCTION-mode with the "UserOverview" feature. Also tested modifying "src/main/java/com/bunq/tinker/UserOverview.java", then run "gradle build" again to make the JAR reflect the changes and test "UserOverview --production" again afterwards. This is successful and dumps what I wanted it to dump in the quantity I wanted it to dump it. (Warning: trying to request more accounts or cards than you actually have will make it error out.)

The "gradle install" step still fails with these changes, but considering tinker actually works again now for PRODUCTION and allows to rebuild ("gradle build") (including after making changes to the configuration files): this is at least an improvement to the current state of affairs in the main tinker repository. :) It isn't perfection, but it at least makes it usable again.